### PR TITLE
fix(ci): restaure VAG_files.zip + VAG_image.iso.zip dans la release

### DIFF
--- a/.github/workflows/gatso.yml
+++ b/.github/workflows/gatso.yml
@@ -39,8 +39,13 @@ jobs:
           python3 -m venv .ci-venv
           echo "PATH=$GITHUB_WORKSPACE/.ci-venv/bin:$PATH" >> "$GITHUB_ENV"
           echo "VIRTUAL_ENV=$GITHUB_WORKSPACE/.ci-venv" >> "$GITHUB_ENV"
-          python -m pip install -U pip wheel
-          python -m pip install configparser pandas pillow
+          # NB: les variables écrites dans $GITHUB_ENV ne s'appliquent qu'aux steps SUIVANTS.
+          # Dans CE step, `python` pointe encore sur le Python système — il faut donc viser
+          # explicitement le binaire du venv, sinon pandas/pillow s'installent au mauvais endroit
+          # et mypois.py (cible VAG) plante en ModuleNotFoundError aux steps suivants.
+          VENV_PY="$GITHUB_WORKSPACE/.ci-venv/bin/python"
+          "$VENV_PY" -m pip install -U pip wheel
+          "$VENV_PY" -m pip install configparser pandas pillow
 
       - name: Setup Node.js
         uses: actions/setup-node@v6

--- a/bin/make.sh
+++ b/bin/make.sh
@@ -207,15 +207,11 @@ _unrelease()
 _mount()
 {
     ¶ '_mount'
-    $BIN_DIR/mypois_ctl.sh make
-    $BIN_DIR/gpsbabel_ctl.sh make
-    
-    rc=$?
-
-    if [ $rc != 0 ]
-    then
-      exit $rc
-    fi
+    # On vérifie le code retour de CHAQUE générateur. Auparavant seul celui de gpsbabel
+    # était testé: un échec de mypois (cible VAG) passait en silence -> release amputée
+    # de VAG_files.zip / VAG_image.iso.zip sans que le build n'échoue.
+    $BIN_DIR/mypois_ctl.sh make || exit $?
+    $BIN_DIR/gpsbabel_ctl.sh make || exit $?
 }
 
 

--- a/bin/mypois_ctl.sh
+++ b/bin/mypois_ctl.sh
@@ -129,7 +129,13 @@ _run()
     ¶ '_run'
     _unmount
 
-    python "$MYPOIS_EXEC" "$CONFIG_PATH"
+    # On propage l'échec: sans ça, un crash de mypois.py (ex: ModuleNotFoundError)
+    # n'empêchait pas le script de retourner 0, et la cible VAG manquait silencieusement.
+    if ! python "$MYPOIS_EXEC" "$CONFIG_PATH"
+    then
+        echo "[ERROR] mypois.py a échoué (cible VAG non générée)" >&2
+        exit 1
+    fi
 }
 
 _update_version()

--- a/bin/mypois_ctl.sh
+++ b/bin/mypois_ctl.sh
@@ -57,11 +57,13 @@ _install()
     tar -xzf "$MYPOIS_GZ_PATH" -C "$MYPOIS_PATH" --strip-components 1 || exit 1
     rm -f "$MYPOIS_GZ_PATH"
 
-    # Compat Python 3.12+: ConfigParser.readfp() (déprécié depuis 3.2) a été SUPPRIMÉ en 3.12.
-    # mypois (amont non maintenu, ~2019) l'utilise encore -> AttributeError sur les runners
-    # actuels (ubuntu-latest = Python 3.12). read_file() est l'équivalent exact, dispo depuis 3.2.
-    # perl -i pour la portabilité (sed -i diffère entre GNU/BSD).
-    perl -pi -e 's/\.readfp\(/.read_file(/g' "$MYPOIS_PATH"/*.py || exit 1
+    # Compat librairies modernes: mypois (amont jimmyH/mypois non maintenu depuis ~2019)
+    # cible des API supprimées dans les versions actuelles de Python/Pillow présentes sur
+    # ubuntu-latest (Python 3.12, Pillow 12). On patche le code téléchargé par des
+    # équivalents stricts. perl -i pour la portabilité (sed -i diffère entre GNU/BSD).
+    #  - ConfigParser.readfp()  : déprécié dès Py 3.2, SUPPRIMÉ en 3.12  -> read_file() (idem)
+    #  - PIL Image.ANTIALIAS    : SUPPRIMÉ en Pillow 10 (n'était qu'un alias) -> Image.LANCZOS
+    perl -pi -e 's/\.readfp\(/.read_file(/g; s/Image\.ANTIALIAS/Image.LANCZOS/g' "$MYPOIS_PATH"/*.py || exit 1
 }
 
 

--- a/bin/mypois_ctl.sh
+++ b/bin/mypois_ctl.sh
@@ -56,6 +56,12 @@ _install()
     mkdir -p "$MYPOIS_PATH"
     tar -xzf "$MYPOIS_GZ_PATH" -C "$MYPOIS_PATH" --strip-components 1 || exit 1
     rm -f "$MYPOIS_GZ_PATH"
+
+    # Compat Python 3.12+: ConfigParser.readfp() (déprécié depuis 3.2) a été SUPPRIMÉ en 3.12.
+    # mypois (amont non maintenu, ~2019) l'utilise encore -> AttributeError sur les runners
+    # actuels (ubuntu-latest = Python 3.12). read_file() est l'équivalent exact, dispo depuis 3.2.
+    # perl -i pour la portabilité (sed -i diffère entre GNU/BSD).
+    perl -pi -e 's/\.readfp\(/.read_file(/g' "$MYPOIS_PATH"/*.py || exit 1
 }
 
 

--- a/readme.md
+++ b/readme.md
@@ -76,8 +76,8 @@ you should read `./bin/make.sh --help`, `./bin/mypois_ctl.sh help`, and `./bin/g
 ## documentation
 
 ### Speed Camera
-REST service from:
-* ![version GATSO FR](https://raw.githubusercontent.com/1e1/Open-GATSO-POI/gh-pages/cnx/gatso-FR.svg?sanitize=true) https://radars.securite-routiere.gouv.fr/ 
+Open data sources:
+* ![version GATSO FR](https://raw.githubusercontent.com/1e1/Open-GATSO-POI/gh-pages/cnx/gatso-FR.svg?sanitize=true) https://www.data.gouv.fr/datasets/liste-des-radars-fixes-en-france/ — official "Liste des radars fixes en France" CSV (Ministère de l'Intérieur). Replaces the per-radar REST API of radars.securite-routiere.gouv.fr, which is unreachable from CI runners (WAF). One bulk download; sections (vitesse moyenne) are single points.
 * ![version GATSO EU](https://raw.githubusercontent.com/1e1/Open-GATSO-POI/gh-pages/cnx/gatso-EU.svg?sanitize=true) https://lufop.net/zones-de-danger-france-et-europe-asc-et-csv/
 * ![version FUEL FR](https://raw.githubusercontent.com/1e1/Open-GATSO-POI/gh-pages/cnx/fuel-FR.svg?sanitize=true) https://www.prix-carburants.gouv.fr/rubrique/opendata/
 


### PR DESCRIPTION
## Problème
Depuis le passage à GitHub Actions, la release `GATSO-master` ne publie plus `VAG_files.zip` ni `VAG_image.iso.zip` (présents dans l'ancienne release Travis `travis_master.2021-08-06`). Garmin, lui, sortait toujours.

## Cause racine (3 bugs en cascade, masqués les uns par les autres)
1. **venv** : dans le step *Python venv*, `python -m pip install pandas pillow` s'exécutait avant que le `PATH` du venv (écrit dans `$GITHUB_ENV`, effectif aux steps suivants seulement) ne prenne effet → paquets installés dans le Python système, alors que les steps suivants utilisaient le venv sans pandas. mypois.py (cible VAG) plantait en `ModuleNotFoundError: No module named 'pandas'`.
2. **Python 3.12** : `ConfigParser.readfp()` (utilisé par mypois, amont ~2019) a été supprimé en 3.12 (`ubuntu-latest` = Ubuntu 24.04).
3. **Pillow 10+** : `Image.ANTIALIAS` supprimé (Pillow 12 installé).

Et comme `_mount()` ne testait que le code retour de gpsbabel (Garmin), l'échec de mypois passait **en silence** → release « réussie » mais amputée de VAG.

## Correctifs
- `gatso.yml` : `pip install` ciblant explicitement `.ci-venv/bin/python`.
- `mypois_ctl.sh` : patch de compat du code mypois téléchargé (`readfp`→`read_file`, `Image.ANTIALIAS`→`Image.LANCZOS`) ; `_run()` propage désormais l'échec de mypois.py.
- `make.sh` : `_mount()` teste le rc de mypois **et** de gpsbabel (plus d'échec VAG silencieux).

## Validation
Build vert sur `develop` (run 28160007265). `./RELEASES` contient à nouveau `VAG_files.zip`, `VAG_image.iso.zip` et toutes les variantes préfixées.

🤖 Generated with [Claude Code](https://claude.com/claude-code)