### PR TITLE
ci(gatso): build hebdo planifié + release roulante

### DIFF
--- a/.github/workflows/gatso.yml
+++ b/.github/workflows/gatso.yml
@@ -8,6 +8,10 @@ on:
     branches: [master, develop]
   pull_request:
     branches: [master, develop]
+  schedule:
+    # Rafraîchissement hebdo des données radars : tous les dimanches à 06h00 UTC.
+    - cron: "0 6 * * 0"
+  workflow_dispatch: {}
 
 concurrency:
   group: gatso-${{ github.workflow }}-${{ github.ref }}
@@ -110,7 +114,10 @@ jobs:
           ls -lR ./RELEASES
 
       - name: Archive pour déploiement (artefact)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: >-
+          (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
+          github.event_name == 'schedule' ||
+          (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master')
         uses: actions/upload-artifact@v7
         with:
           name: gatso-deploy
@@ -125,7 +132,10 @@ jobs:
           retention-days: 2
 
   deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master')
     needs: build
     runs-on: ubuntu-latest
     permissions:
@@ -149,16 +159,21 @@ jobs:
             exit 1
           fi
           GATSO_UPDATE_MAX=$(date -d @$(cat BUILD/version.txt | sort -n | tail -1) +%Y-%m-%d)
-          TAG="${TAG_PREFIX}master.${GATSO_UPDATE_MAX}"
+          # Release ROULANTE : tag fixe (sans date) réutilisé à chaque run.
+          # action-gh-release met à jour la release existante et écrase les assets
+          # de même nom (les noms sont déterministes, ex: FR-gatso-*.zip) -> pas
+          # d'accumulation de releases/tags datés au fil des runs hebdo.
+          TAG="${TAG_PREFIX}master"
           echo "GATSO_UPDATE_MAX=$GATSO_UPDATE_MAX"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "release_name=${TAG_PREFIX}master" >> "$GITHUB_OUTPUT"
+          echo "release_name=${TAG_PREFIX}master (${GATSO_UPDATE_MAX})" >> "$GITHUB_OUTPUT"
 
       - name: Publier la release (assets dans RELEASES/)
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           name: ${{ steps.meta.outputs.release_name }}
           tag_name: ${{ steps.meta.outputs.tag }}
+          target_commitish: ${{ github.sha }}
           body_path: BUILD/manifest.txt
           fail_on_unmatched_files: false
           make_latest: true


### PR DESCRIPTION
## Objectif
Mettre le site/les jeux de données à jour automatiquement **chaque semaine**, sans accumuler de releases.

## Changements ([gatso.yml](.github/workflows/gatso.yml))
1. **Déclencheurs** : ajout d'un `schedule` cron `0 6 * * 0` (dimanche 06h UTC) + `workflow_dispatch` (bouton manuel "Run workflow").
2. **Conditions build/deploy** élargies pour couvrir `schedule` et `workflow_dispatch` (sinon le run planifié ne déploierait pas).
3. **Release roulante** : le tag passe de `${PREFIX}master.<date>` à un **tag fixe** `${PREFIX}master`. `action-gh-release` met à jour la release existante et **écrase les assets de même nom** (noms déterministes, ex `FR-gatso-*.zip`). La date reste visible dans le **titre** de la release.

## Effet
- Site Pages + downloads rafraîchis chaque dimanche.
- Plus d'accumulation de releases/tags datés (la fuite actuelle est stoppée à la source).
- `target_commitish: github.sha` pour que le tag fixe suive bien le dernier commit master.

## Compatibilité
100 % gratuit (repo public : minutes Actions illimitées). Cron peut être désactivé après 60j d'inactivité du repo (réactivable d'un clic).

## Suite (PR/action séparée)
Nettoyage des anciennes releases `travis_master.*` et `GATSO-master.*` datées une fois la rolling `${PREFIX}master` produite.