### PR TITLE
ci(gatso): build hebdo planifié + release roulante

### DIFF
--- a/.github/workflows/gatso.yml
+++ b/.github/workflows/gatso.yml
@@ -8,6 +8,10 @@ on:
     branches: [master, develop]
   pull_request:
     branches: [master, develop]
+  schedule:
+    # Rafraîchissement hebdo des données radars : tous les dimanches à 06h00 UTC.
+    - cron: "0 6 * * 0"
+  workflow_dispatch: {}
 
 concurrency:
   group: gatso-${{ github.workflow }}-${{ github.ref }}
@@ -115,7 +119,10 @@ jobs:
           ls -lR ./RELEASES
 
       - name: Archive pour déploiement (artefact)
-        if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+        if: >-
+          (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
+          github.event_name == 'schedule' ||
+          (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master')
         uses: actions/upload-artifact@v7
         with:
           name: gatso-deploy
@@ -130,7 +137,10 @@ jobs:
           retention-days: 2
 
   deploy:
-    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/master') ||
+      github.event_name == 'schedule' ||
+      (github.event_name == 'workflow_dispatch' && github.ref == 'refs/heads/master')
     needs: build
     runs-on: ubuntu-latest
     permissions:
@@ -154,16 +164,21 @@ jobs:
             exit 1
           fi
           GATSO_UPDATE_MAX=$(date -d @$(cat BUILD/version.txt | sort -n | tail -1) +%Y-%m-%d)
-          TAG="${TAG_PREFIX}master.${GATSO_UPDATE_MAX}"
+          # Release ROULANTE : tag fixe (sans date) réutilisé à chaque run.
+          # action-gh-release met à jour la release existante et écrase les assets
+          # de même nom (les noms sont déterministes, ex: FR-gatso-*.zip) -> pas
+          # d'accumulation de releases/tags datés au fil des runs hebdo.
+          TAG="${TAG_PREFIX}master"
           echo "GATSO_UPDATE_MAX=$GATSO_UPDATE_MAX"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "release_name=${TAG_PREFIX}master" >> "$GITHUB_OUTPUT"
+          echo "release_name=${TAG_PREFIX}master (${GATSO_UPDATE_MAX})" >> "$GITHUB_OUTPUT"
 
       - name: Publier la release (assets dans RELEASES/)
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2
         with:
           name: ${{ steps.meta.outputs.release_name }}
           tag_name: ${{ steps.meta.outputs.tag }}
+          target_commitish: ${{ github.sha }}
           body_path: BUILD/manifest.txt
           fail_on_unmatched_files: false
           make_latest: true

--- a/.github/workflows/gatso.yml
+++ b/.github/workflows/gatso.yml
@@ -164,14 +164,22 @@ jobs:
             exit 1
           fi
           GATSO_UPDATE_MAX=$(date -d @$(cat BUILD/version.txt | sort -n | tail -1) +%Y-%m-%d)
-          # Release ROULANTE : tag fixe (sans date) réutilisé à chaque run.
-          # action-gh-release met à jour la release existante et écrase les assets
-          # de même nom (les noms sont déterministes, ex: FR-gatso-*.zip) -> pas
-          # d'accumulation de releases/tags datés au fil des runs hebdo.
-          TAG="${TAG_PREFIX}master"
-          echo "GATSO_UPDATE_MAX=$GATSO_UPDATE_MAX"
+          # Modèle "1 release par version de code" :
+          #   - le tag suit la version de src/package.json (ex: v1.2.0) ;
+          #   - les runs planifiés (data only) RÉUTILISENT ce tag -> action-gh-release
+          #     met à jour la release existante et écrase les assets de même nom
+          #     (noms déterministes, ex: FR-gatso-*.zip) ;
+          #   - une NOUVELLE release n'apparaît que si la version est bumpée
+          #     (= vrai changement de code). Pas d'accumulation de releases datées.
+          VERSION=$(jq -r '.version' src/package.json)
+          if [ -z "$VERSION" ] || [ "$VERSION" = "null" ]; then
+            echo "version introuvable dans src/package.json"
+            exit 1
+          fi
+          TAG="${TAG_PREFIX}v${VERSION}"
+          echo "GATSO_UPDATE_MAX=$GATSO_UPDATE_MAX  VERSION=$VERSION"
           echo "tag=$TAG" >> "$GITHUB_OUTPUT"
-          echo "release_name=${TAG_PREFIX}master (${GATSO_UPDATE_MAX})" >> "$GITHUB_OUTPUT"
+          echo "release_name=${TAG_PREFIX}v${VERSION} (data ${GATSO_UPDATE_MAX})" >> "$GITHUB_OUTPUT"
 
       - name: Publier la release (assets dans RELEASES/)
         uses: softprops/action-gh-release@3bb12739c298aeb8a4eeaf626c5b8d85266b0e65 # v2.6.2


### PR DESCRIPTION
## Objectif
Mettre à jour site + jeux de données **chaque semaine**, sans accumuler de releases.

## Modèle retenu : **1 release par version de code**
- Le tag suit `src/package.json` : `${PREFIX}v<version>` (ex `GATSO-v1.2.0`).
- Les runs **planifiés** (data only) **réutilisent** ce tag → `action-gh-release` met à jour la release existante et **écrase les assets de même nom**.
- Une **nouvelle release** n'apparaît **que si la version est bumpée** (= vrai changement de code).
- La **date de la data** reste visible dans le titre : `GATSO-v1.2.0 (data YYYY-MM-DD)`.

Cf. analyse historique : 30 releases `travis_master.*` ne correspondaient qu'à **2 états de code** — 28 étaient de la pure data. Ce modèle aurait donné 2 releases au lieu de 30.

## Changements ([gatso.yml](.github/workflows/gatso.yml))
1. **Déclencheurs** : `schedule` cron `0 6 * * 0` (dimanche 06h UTC) + `workflow_dispatch`.
2. **Conditions build/deploy** élargies à `schedule` + `workflow_dispatch`.
3. **Métadonnées release** : tag = version package.json (au lieu de la date) ; `target_commitish: github.sha`.

## Notes
- 100 % gratuit (repo public). Déploiement réel gated sur `master` (cette PR valide surtout le **build**).
- Suite : nettoyage des `travis_master.*` + `GATSO-master.<date>` une fois une rolling `GATSO-v*` produite sur master (script avec garde-fou prêt).